### PR TITLE
This adds support for GSON TypeAdapters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ObadiahCrowe</groupId>
     <artifactId>MongoUtil</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/me/obadiahpcrowe/mongoutil/MongoManager.java
+++ b/src/main/java/me/obadiahpcrowe/mongoutil/MongoManager.java
@@ -69,7 +69,7 @@ public class MongoManager {
     }
 
     private Object getObject(DBCollection collection, Map<String, Object> identifiers, Class returnableObject) { return getObject(collection, identifiers, returnableObject, null); }
-    private Object getObject(DBCollection collection, Map<String, Object> identifiers, Class returnableObject, Map<Class, TypeAdapter> adapters) {
+    private Object getObject(DBCollection collection, Map<String, Object> identifiers, Class returnableObject, Map<Class, Object> adapters) {
         BasicDBObject query = new BasicDBObject();
         Gson gson = setAdapters(adapters);
 
@@ -100,7 +100,7 @@ public class MongoManager {
         }
     }
     private void insertObject(DBCollection collection, Object insertableObject) { insertObject(collection, insertableObject, null); }
-    private void insertObject(DBCollection collection, Object insertableObject, Map<Class, TypeAdapter> adapters) {
+    private void insertObject(DBCollection collection, Object insertableObject, Map<Class, Object> adapters) {
         Gson gson = setAdapters(adapters);
         BasicDBObject query = BasicDBObject.parse(gson.toJson(insertableObject));
 
@@ -121,7 +121,7 @@ public class MongoManager {
     private void updateObject(DBCollection collection, Map<String, Object> identifiers, String updateField,
                               Object insertableObject) { updateObject(collection, identifiers, updateField, insertableObject, null); }
     private void updateObject(DBCollection collection, Map<String, Object> identifiers, String updateField,
-                              Object insertableObject, Map<Class, TypeAdapter> adapters) {
+                              Object insertableObject, Map<Class, Object> adapters) {
         Gson gson = setAdapters(adapters);
         BasicDBObject object = new BasicDBObject();
         object.append("$set", new BasicDBObject().append(updateField, gson.toJson(insertableObject)));
@@ -136,11 +136,11 @@ public class MongoManager {
         collection.update(query, object);
     }
 
-    private Gson setAdapters(Map<Class, TypeAdapter> adapters) {
+    private Gson setAdapters(Map<Class, Object> adapters) {
         Gson gson = this.gson;
         if (adapters != null) {
             GsonBuilder gsonBuilder = new GsonBuilder();
-            for (Map.Entry<Class, TypeAdapter> entrySet : adapters.entrySet()) {
+            for (Map.Entry<Class, Object> entrySet : adapters.entrySet()) {
                 gsonBuilder.registerTypeAdapter(entrySet.getKey(), entrySet.getValue());
             }
             gson = gsonBuilder.create();

--- a/src/main/java/me/obadiahpcrowe/mongoutil/MongoManager.java
+++ b/src/main/java/me/obadiahpcrowe/mongoutil/MongoManager.java
@@ -51,10 +51,10 @@ public class MongoManager {
 
         switch (mongoCall.getCallType()) {
             case GET:
-                returnableObject = getObject(collection, mongoCall.getIdentifiers(), mongoCall.getReturnableObject());
+                returnableObject = getObject(collection, mongoCall.getIdentifiers(), mongoCall.getReturnableObject(), mongoCall.getAdapters());
                 break;
             case INSERT:
-                insertObject(collection, mongoCall.getInsertableObject());
+                insertObject(collection, mongoCall.getInsertableObject(), mongoCall.getAdapters());
                 break;
             case REMOVE:
                 deleteObject(collection, mongoCall.getIdentifiers());

--- a/src/main/java/me/obadiahpcrowe/mongoutil/MongoManager.java
+++ b/src/main/java/me/obadiahpcrowe/mongoutil/MongoManager.java
@@ -1,6 +1,8 @@
 package me.obadiahpcrowe.mongoutil;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
@@ -66,8 +68,18 @@ public class MongoManager {
         return returnableObject;
     }
 
-    private Object getObject(DBCollection collection, Map<String, Object> identifiers, Class returnableObject) {
+    private Object getObject(DBCollection collection, Map<String, Object> identifiers, Class returnableObject) { return getObject(collection, identifiers, returnableObject, null); }
+    private Object getObject(DBCollection collection, Map<String, Object> identifiers, Class returnableObject, Map<Class, TypeAdapter> adapters) {
         BasicDBObject query = new BasicDBObject();
+        Gson gson = this.gson;
+        if (adapters != null) {
+            GsonBuilder gsonBuilder = new GsonBuilder();
+            for (Map.Entry<Class, TypeAdapter> entrySet : adapters.entrySet()) {
+                gsonBuilder.registerTypeAdapter(entrySet.getKey(), entrySet.getValue());
+            }
+            gson = gsonBuilder.create();
+        }
+
         if (identifiers.size() <= 0) {
             DBCursor cursor = collection.find();
             List<Object> objects = new ArrayList<>();
@@ -94,8 +106,17 @@ public class MongoManager {
             return null;
         }
     }
+    private void insertObject(DBCollection collection, Object insertableObject) { insertObject(collection, insertableObject, null); }
+    private void insertObject(DBCollection collection, Object insertableObject, Map<Class, TypeAdapter> adapters) {
+        Gson gson = this.gson;
+        if (adapters != null) {;
+            GsonBuilder gsonBuilder = new GsonBuilder();
+            for (Map.Entry<Class, TypeAdapter> entrySet : adapters.entrySet()) {
+                gsonBuilder.registerTypeAdapter(entrySet.getKey(), entrySet.getValue());
+            }
+            gson = gsonBuilder.create();
+        }
 
-    private void insertObject(DBCollection collection, Object insertableObject) {
         BasicDBObject query = BasicDBObject.parse(gson.toJson(insertableObject));
         collection.insert(query);
     }

--- a/src/main/java/me/obadiahpcrowe/mongoutil/obj/MongoCall.java
+++ b/src/main/java/me/obadiahpcrowe/mongoutil/obj/MongoCall.java
@@ -1,5 +1,6 @@
 package me.obadiahpcrowe.mongoutil.obj;
 
+import com.google.gson.TypeAdapter;
 import lombok.Getter;
 import me.obadiahpcrowe.mongoutil.enums.CallType;
 
@@ -19,6 +20,7 @@ public class MongoCall {
     private MongoDB database;
     private CallType callType;
     private Map<String, Object> identifiers;
+    private Map<Class, TypeAdapter> adapters;
     private Object insertableObject;
     private String updateField;
     private Class returnableObject;
@@ -26,6 +28,11 @@ public class MongoCall {
     public MongoCall(String dbName, MongoDB database) {
         this.dbName = dbName;
         this.database = database;
+    }
+
+    public MongoCall setAdapters(Map<Class, TypeAdapter> adapters) {
+        this.adapters = adapters;
+        return this;
     }
 
     public MongoCall get(Map<String, Object> identifiers, Class returnableObject) {
@@ -60,5 +67,9 @@ public class MongoCall {
         this.identifiers = identifiers;
         this.insertableObject = insertableObject;
         return this;
+    }
+
+    public MongoDB getDatabase() {
+        return this.database;
     }
 }

--- a/src/main/java/me/obadiahpcrowe/mongoutil/obj/MongoCall.java
+++ b/src/main/java/me/obadiahpcrowe/mongoutil/obj/MongoCall.java
@@ -20,7 +20,7 @@ public class MongoCall {
     private MongoDB database;
     private CallType callType;
     private Map<String, Object> identifiers;
-    private Map<Class, TypeAdapter> adapters;
+    private Map<Class, Object> adapters;
     private Object insertableObject;
     private String updateField;
     private Class returnableObject;
@@ -30,7 +30,7 @@ public class MongoCall {
         this.database = database;
     }
 
-    public MongoCall setAdapters(Map<Class, TypeAdapter> adapters) {
+    public MongoCall setAdapters(Map<Class, Object> adapters) {
         this.adapters = adapters;
         return this;
     }


### PR DESCRIPTION
TypeAdapters can be added to a MongoCall by adding: `.setAdapters(new HashMap<Class, TypeAdapter>(){{
put([Class], new [TypeAdapter]);
...
}}`

setAdapters(...) returns the MongoCall object, and thus it can be used directly in-line with MongoCall like so: `new MongoCall(parameters).setAdapters(...);`